### PR TITLE
Fix drawdown duration calculation

### DIFF
--- a/optimization_bet/analayse_strat_bet.py
+++ b/optimization_bet/analayse_strat_bet.py
@@ -827,7 +827,7 @@ class UFCBettingOptimizerAggressiveFrequentDD30:
         drawdown_periods = []
         in_drawdown = False
         start = 0
-        
+
         for i in range(len(drawdown)):
             if drawdown.iloc[i] < 0 and not in_drawdown:
                 in_drawdown = True
@@ -835,7 +835,11 @@ class UFCBettingOptimizerAggressiveFrequentDD30:
             elif drawdown.iloc[i] >= 0 and in_drawdown:
                 in_drawdown = False
                 drawdown_periods.append(i - start)
-        
+
+        # If we end in drawdown, account for the ongoing period
+        if in_drawdown:
+            drawdown_periods.append(len(drawdown) - start)
+
         max_drawdown_duration = max(drawdown_periods) if drawdown_periods else 0
         
         # Pertes consécutives maximales


### PR DESCRIPTION
## Summary
- fix computation of max drawdown duration in optimizer

## Testing
- `python -m py_compile optimization_bet/analayse_strat_bet.py`

------
https://chatgpt.com/codex/tasks/task_e_685a61a12f7c83328e5c2d775dc5e9d4